### PR TITLE
cordova-plugin-barcode-scanner.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-barcode-scanner/cordova-plugin-barcode-scanner.dev/descr
+++ b/packages/cordova-plugin-barcode-scanner/cordova-plugin-barcode-scanner.dev/descr
@@ -1,0 +1,1 @@
+Binding to the barcode scanner cordova plugin using gen_js_api

--- a/packages/cordova-plugin-barcode-scanner/cordova-plugin-barcode-scanner.dev/opam
+++ b/packages/cordova-plugin-barcode-scanner/cordova-plugin-barcode-scanner.dev/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-barcodescanner"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-barcodescanner/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-barcodescanner"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-barcode-scanner/cordova-plugin-barcode-scanner.dev/url
+++ b/packages/cordova-plugin-barcode-scanner/cordova-plugin-barcode-scanner.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-barcodescanner/archive/dev.tar.gz"
+checksum: "bf8e4ed0b544a716b08afc784e45a4a1"


### PR DESCRIPTION
Binding to the barcode scanner cordova plugin using gen_js_api

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-barcodescanner
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-barcodescanner
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-barcodescanner/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
