### PR TITLE
cordova-plugin-activity-indicator.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.dev/descr
+++ b/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.dev/descr
@@ -1,0 +1,1 @@
+Bindings OCaml to cordova plugin activity indicator using gen_js_api

--- a/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.dev/opam
+++ b/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.dev/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-activityindicator"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-activityindicator/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-activityindicator"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.dev/url
+++ b/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-activityindicator/archive/dev.tar.gz"
+checksum: "2cc8ab02b859b66ef4585254e9f18595"


### PR DESCRIPTION
Bindings OCaml to cordova plugin activity indicator using gen_js_api

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-activityindicator
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-activityindicator
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-activityindicator/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
