### PR TITLE
cordova-plugin-camera.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-camera/cordova-plugin-camera.dev/descr
+++ b/packages/cordova-plugin-camera/cordova-plugin-camera.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova plugin camera using gen_js_api

--- a/packages/cordova-plugin-camera/cordova-plugin-camera.dev/opam
+++ b/packages/cordova-plugin-camera/cordova-plugin-camera.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-camera"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-camera/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-camera"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-camera/cordova-plugin-camera.dev/url
+++ b/packages/cordova-plugin-camera/cordova-plugin-camera.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-camera/archive/dev.tar.gz"
+checksum: "ddad64417ff40cef10bbe843085b0681"


### PR DESCRIPTION
Binding OCaml to cordova plugin camera using gen_js_api

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-camera
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-camera
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-camera/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
