### PR TITLE
cordova-plugin-clipboard.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-clipboard/cordova-plugin-clipboard.dev/descr
+++ b/packages/cordova-plugin-clipboard/cordova-plugin-clipboard.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-universal-clipboard using gen_js_api.

--- a/packages/cordova-plugin-clipboard/cordova-plugin-clipboard.dev/opam
+++ b/packages/cordova-plugin-clipboard/cordova-plugin-clipboard.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-clipboard"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-clipboard/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-clipboard"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-clipboard/cordova-plugin-clipboard.dev/url
+++ b/packages/cordova-plugin-clipboard/cordova-plugin-clipboard.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-clipboard/archive/dev.tar.gz"
+checksum: "31329c2449dff82e7a0c0110bb9f809e"


### PR DESCRIPTION
Binding OCaml to cordova-universal-clipboard using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-clipboard
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-clipboard
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-clipboard/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
