### PR TITLE
cordova-plugin-device.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-device/cordova-plugin-device.dev/descr
+++ b/packages/cordova-plugin-device/cordova-plugin-device.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-device using gen_js_api

--- a/packages/cordova-plugin-device/cordova-plugin-device.dev/opam
+++ b/packages/cordova-plugin-device/cordova-plugin-device.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-device"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-device/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-device"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-device/cordova-plugin-device.dev/url
+++ b/packages/cordova-plugin-device/cordova-plugin-device.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-device/archive/dev.tar.gz"
+checksum: "6ec88898ffb0bc54383b9df52d12cdc2"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-device using gen_js_api

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-device
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-device
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-device/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
