### PR TITLE
cordova-plugin-device-motion.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-device-motion/cordova-plugin-device-motion.dev/descr
+++ b/packages/cordova-plugin-device-motion/cordova-plugin-device-motion.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-device-motion using gen_js_api.

--- a/packages/cordova-plugin-device-motion/cordova-plugin-device-motion.dev/opam
+++ b/packages/cordova-plugin-device-motion/cordova-plugin-device-motion.dev/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-device-motion"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-device-motion/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-device-motion"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: ["gen_js_api" "ocaml-js-stdlib"]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-device-motion/cordova-plugin-device-motion.dev/url
+++ b/packages/cordova-plugin-device-motion/cordova-plugin-device-motion.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-device-motion/archive/dev.tar.gz"
+checksum: "91f1fa46f8a996b812c5347bb61697d0"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-device-motion using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-device-motion
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-device-motion
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-device-motion/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
