### PR TITLE
cordova-plugin-file.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-file/cordova-plugin-file.dev/descr
+++ b/packages/cordova-plugin-file/cordova-plugin-file.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-file using gen_js_api.

--- a/packages/cordova-plugin-file/cordova-plugin-file.dev/opam
+++ b/packages/cordova-plugin-file/cordova-plugin-file.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-file"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-file/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-file"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-file/cordova-plugin-file.dev/url
+++ b/packages/cordova-plugin-file/cordova-plugin-file.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-file/archive/dev.tar.gz"
+checksum: "b34e597e5c307ce9e9c10405162b310c"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-file using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-file
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-file
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-file/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
