### PR TITLE
cordova-plugin-file-opener.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-file-opener/cordova-plugin-file-opener.dev/descr
+++ b/packages/cordova-plugin-file-opener/cordova-plugin-file-opener.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-file-opener using gen_js_api.

--- a/packages/cordova-plugin-file-opener/cordova-plugin-file-opener.dev/opam
+++ b/packages/cordova-plugin-file-opener/cordova-plugin-file-opener.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-file-opener"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-file-opener/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-file-opener"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-file-opener/cordova-plugin-file-opener.dev/url
+++ b/packages/cordova-plugin-file-opener/cordova-plugin-file-opener.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-file-opener/archive/dev.tar.gz"
+checksum: "260771a61b1b61948e15c7219c22d5f0"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-file-opener using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-file-opener
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-file-opener
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-file-opener/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
