### PR TITLE
cordova-plugin-geolocation.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-geolocation/cordova-plugin-geolocation.dev/descr
+++ b/packages/cordova-plugin-geolocation/cordova-plugin-geolocation.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-geolocation using gen_js_api.

--- a/packages/cordova-plugin-geolocation/cordova-plugin-geolocation.dev/opam
+++ b/packages/cordova-plugin-geolocation/cordova-plugin-geolocation.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-geolocation"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-geolocation/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-geolocation"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-geolocation/cordova-plugin-geolocation.dev/url
+++ b/packages/cordova-plugin-geolocation/cordova-plugin-geolocation.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-geolocation/archive/dev.tar.gz"
+checksum: "c785776ee3188bab01499daa65376d2e"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-geolocation using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-geolocation
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-geolocation
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-geolocation/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
