### PR TITLE
cordova-plugin-image-picker.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-image-picker/cordova-plugin-image-picker.dev/descr
+++ b/packages/cordova-plugin-image-picker/cordova-plugin-image-picker.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-image-picker using gen_js_api.

--- a/packages/cordova-plugin-image-picker/cordova-plugin-image-picker.dev/opam
+++ b/packages/cordova-plugin-image-picker/cordova-plugin-image-picker.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-image-picker"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-image-picker/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-image-picker"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-image-picker/cordova-plugin-image-picker.dev/url
+++ b/packages/cordova-plugin-image-picker/cordova-plugin-image-picker.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-image-picker/archive/dev.tar.gz"
+checksum: "ad3ef2f9c036afeeceb0d9d6ab345a3f"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-image-picker using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-image-picker
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-image-picker
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-image-picker/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
