### PR TITLE
cordova-plugin-inappbrowser.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-inappbrowser/cordova-plugin-inappbrowser.dev/descr
+++ b/packages/cordova-plugin-inappbrowser/cordova-plugin-inappbrowser.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-inappbrowser using gen_js_api.

--- a/packages/cordova-plugin-inappbrowser/cordova-plugin-inappbrowser.dev/opam
+++ b/packages/cordova-plugin-inappbrowser/cordova-plugin-inappbrowser.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-inappbrowser"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-inappbrowser/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-inappbrowser"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-inappbrowser/cordova-plugin-inappbrowser.dev/url
+++ b/packages/cordova-plugin-inappbrowser/cordova-plugin-inappbrowser.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-inappbrowser/archive/dev.tar.gz"
+checksum: "f41582643a8a22a3d66c9ac004092396"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-inappbrowser using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-inappbrowser
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-inappbrowser
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-inappbrowser/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
