### PR TITLE
cordova-plugin-insomnia.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-insomnia/cordova-plugin-insomnia.dev/descr
+++ b/packages/cordova-plugin-insomnia/cordova-plugin-insomnia.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to Insomnia-PhoneGap-Plugin using gen_js_api.

--- a/packages/cordova-plugin-insomnia/cordova-plugin-insomnia.dev/opam
+++ b/packages/cordova-plugin-insomnia/cordova-plugin-insomnia.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-insomnia"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-insomnia/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-insomnia"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-insomnia/cordova-plugin-insomnia.dev/url
+++ b/packages/cordova-plugin-insomnia/cordova-plugin-insomnia.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-insomnia/archive/dev.tar.gz"
+checksum: "a8a9282e612d32bed606a6f8bce62581"


### PR DESCRIPTION
Binding OCaml to Insomnia-PhoneGap-Plugin using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-insomnia
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-insomnia
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-insomnia/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
