### PR TITLE
cordova-plugin-loading-spinner.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-loading-spinner/cordova-plugin-loading-spinner.dev/descr
+++ b/packages/cordova-plugin-loading-spinner/cordova-plugin-loading-spinner.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to phonegap-plugin-loading-spinner using gen_js_api.

--- a/packages/cordova-plugin-loading-spinner/cordova-plugin-loading-spinner.dev/opam
+++ b/packages/cordova-plugin-loading-spinner/cordova-plugin-loading-spinner.dev/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-loading-spinner"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-loading-spinner/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-loading-spinner"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-loading-spinner/cordova-plugin-loading-spinner.dev/url
+++ b/packages/cordova-plugin-loading-spinner/cordova-plugin-loading-spinner.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-loading-spinner/archive/dev.tar.gz"
+checksum: "659e8cb74d464ac9fcb31abafb1873da"


### PR DESCRIPTION
Binding OCaml to phonegap-plugin-loading-spinner using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-loading-spinner
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-loading-spinner
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-loading-spinner/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
