### PR TITLE
cordova-plugin-media.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-media/cordova-plugin-media.dev/descr
+++ b/packages/cordova-plugin-media/cordova-plugin-media.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-media using gen_js_api.

--- a/packages/cordova-plugin-media/cordova-plugin-media.dev/opam
+++ b/packages/cordova-plugin-media/cordova-plugin-media.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-media"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-media/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-media"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-media/cordova-plugin-media.dev/url
+++ b/packages/cordova-plugin-media/cordova-plugin-media.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-media/archive/dev.tar.gz"
+checksum: "77235ebdab1fc1b611d710d2566f9e18"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-media using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-media
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-media
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-media/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
