### PR TITLE
cordova-plugin-media-capture.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-media-capture/cordova-plugin-media-capture.dev/descr
+++ b/packages/cordova-plugin-media-capture/cordova-plugin-media-capture.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-media-capture using gen_js_api.

--- a/packages/cordova-plugin-media-capture/cordova-plugin-media-capture.dev/opam
+++ b/packages/cordova-plugin-media-capture/cordova-plugin-media-capture.dev/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-media-capture"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-media-capture/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-media-capture"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-media-capture/cordova-plugin-media-capture.dev/url
+++ b/packages/cordova-plugin-media-capture/cordova-plugin-media-capture.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-media-capture/archive/dev.tar.gz"
+checksum: "08bdbc4900d1bfd6a41e7b6964b7b7bd"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-media-capture using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-media-capture
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-media-capture
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-media-capture/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
