### PR TITLE
cordova-plugin-progress.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-progress/cordova-plugin-progress.dev/descr
+++ b/packages/cordova-plugin-progress/cordova-plugin-progress.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-progress using gen_js_api.

--- a/packages/cordova-plugin-progress/cordova-plugin-progress.dev/opam
+++ b/packages/cordova-plugin-progress/cordova-plugin-progress.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-progress"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-progress/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-progress"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-progress/cordova-plugin-progress.dev/url
+++ b/packages/cordova-plugin-progress/cordova-plugin-progress.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-progress/archive/dev.tar.gz"
+checksum: "1842be029fe6b6672566433d69032a96"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-progress using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-progress
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-progress
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-progress/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
