### PR TITLE
cordova-plugin-qrscanner.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-qrscanner/cordova-plugin-qrscanner.dev/descr
+++ b/packages/cordova-plugin-qrscanner/cordova-plugin-qrscanner.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-qrscanner using gen_js_api.

--- a/packages/cordova-plugin-qrscanner/cordova-plugin-qrscanner.dev/opam
+++ b/packages/cordova-plugin-qrscanner/cordova-plugin-qrscanner.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-qrscanner"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-qrscanner/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-qrscanner"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-qrscanner/cordova-plugin-qrscanner.dev/url
+++ b/packages/cordova-plugin-qrscanner/cordova-plugin-qrscanner.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-qrscanner/archive/dev.tar.gz"
+checksum: "35f6aac3deb26d0f92311864c5aa0519"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-qrscanner using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-qrscanner
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-qrscanner
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-qrscanner/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
