### PR TITLE
cordova-plugin-screen-orientation.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-screen-orientation/cordova-plugin-screen-orientation.dev/descr
+++ b/packages/cordova-plugin-screen-orientation/cordova-plugin-screen-orientation.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-screen-orientation using gen_js_api.

--- a/packages/cordova-plugin-screen-orientation/cordova-plugin-screen-orientation.dev/opam
+++ b/packages/cordova-plugin-screen-orientation/cordova-plugin-screen-orientation.dev/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-screen-orientation"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-screen-orientation/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-screen-orientation"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-screen-orientation/cordova-plugin-screen-orientation.dev/url
+++ b/packages/cordova-plugin-screen-orientation/cordova-plugin-screen-orientation.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-screen-orientation/archive/dev.tar.gz"
+checksum: "df1dd3981eee29c851119d2d1ca8c02c"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-screen-orientation using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-screen-orientation
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-screen-orientation
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-screen-orientation/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
