### PR TITLE
cordova-plugin-sms.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-sms/cordova-plugin-sms.dev/descr
+++ b/packages/cordova-plugin-sms/cordova-plugin-sms.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-sms using gen_js_api.

--- a/packages/cordova-plugin-sms/cordova-plugin-sms.dev/opam
+++ b/packages/cordova-plugin-sms/cordova-plugin-sms.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-sms"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-sms/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-sms"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-sms/cordova-plugin-sms.dev/url
+++ b/packages/cordova-plugin-sms/cordova-plugin-sms.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-sms/archive/dev.tar.gz"
+checksum: "27503872242c39294873006a298fe07b"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-sms using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-sms
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-sms
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-sms/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
