### PR TITLE
cordova-plugin-splashscreen.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-splashscreen/cordova-plugin-splashscreen.dev/descr
+++ b/packages/cordova-plugin-splashscreen/cordova-plugin-splashscreen.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-splashscreen using gen_js_api.

--- a/packages/cordova-plugin-splashscreen/cordova-plugin-splashscreen.dev/opam
+++ b/packages/cordova-plugin-splashscreen/cordova-plugin-splashscreen.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-splashscreen"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-splashscreen/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-splashscreen"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-splashscreen/cordova-plugin-splashscreen.dev/url
+++ b/packages/cordova-plugin-splashscreen/cordova-plugin-splashscreen.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-splashscreen/archive/dev.tar.gz"
+checksum: "9ab2bce50223a48e671bbef695898dd6"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-splashscreen using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-splashscreen
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-splashscreen
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-splashscreen/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
