### PR TITLE
cordova-plugin-statusbar.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-statusbar/cordova-plugin-statusbar.dev/descr
+++ b/packages/cordova-plugin-statusbar/cordova-plugin-statusbar.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-statusbar using gen_js_api.

--- a/packages/cordova-plugin-statusbar/cordova-plugin-statusbar.dev/opam
+++ b/packages/cordova-plugin-statusbar/cordova-plugin-statusbar.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-statusbar"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-statusbar/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-statusbar"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-statusbar/cordova-plugin-statusbar.dev/url
+++ b/packages/cordova-plugin-statusbar/cordova-plugin-statusbar.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-statusbar/archive/dev.tar.gz"
+checksum: "f745a550ab073e263a191a2aaa24250f"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-statusbar using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-statusbar
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-statusbar
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-statusbar/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
