### PR TITLE
cordova-plugin-toast.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-toast/cordova-plugin-toast.dev/descr
+++ b/packages/cordova-plugin-toast/cordova-plugin-toast.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-x-toast using gen_js_api.

--- a/packages/cordova-plugin-toast/cordova-plugin-toast.dev/opam
+++ b/packages/cordova-plugin-toast/cordova-plugin-toast.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-toast"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-toast/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-toast"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-toast/cordova-plugin-toast.dev/url
+++ b/packages/cordova-plugin-toast/cordova-plugin-toast.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-toast/archive/dev.tar.gz"
+checksum: "46a51231e17e3475a3b31054813ee953"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-x-toast using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-toast
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-toast
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-toast/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
