### PR TITLE
cordova-plugin-touchid.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-touchid/cordova-plugin-touchid.dev/descr
+++ b/packages/cordova-plugin-touchid/cordova-plugin-touchid.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-touchid using gen_js_api.

--- a/packages/cordova-plugin-touchid/cordova-plugin-touchid.dev/opam
+++ b/packages/cordova-plugin-touchid/cordova-plugin-touchid.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-touchid"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-touchid/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-touchid"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-touchid/cordova-plugin-touchid.dev/url
+++ b/packages/cordova-plugin-touchid/cordova-plugin-touchid.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-touchid/archive/dev.tar.gz"
+checksum: "5133a1acce63fb7749378250c13a1802"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-touchid using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-touchid
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-touchid
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-touchid/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
