### PR TITLE
cordova-plugin-vibration.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-vibration/cordova-plugin-vibration.dev/descr
+++ b/packages/cordova-plugin-vibration/cordova-plugin-vibration.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-vibration using gen_js_api.

--- a/packages/cordova-plugin-vibration/cordova-plugin-vibration.dev/opam
+++ b/packages/cordova-plugin-vibration/cordova-plugin-vibration.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-vibration"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-vibration/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-vibration"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-vibration/cordova-plugin-vibration.dev/url
+++ b/packages/cordova-plugin-vibration/cordova-plugin-vibration.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-vibration/archive/dev.tar.gz"
+checksum: "9ae93d1205cef5bd48b415f6cb46cd9b"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-vibration using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-vibration
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-vibration
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-vibration/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
