### PR TITLE
cordova-plugin-videoplayer.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-videoplayer/cordova-plugin-videoplayer.dev/descr
+++ b/packages/cordova-plugin-videoplayer/cordova-plugin-videoplayer.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-videoplayer using gen_js_api.

--- a/packages/cordova-plugin-videoplayer/cordova-plugin-videoplayer.dev/opam
+++ b/packages/cordova-plugin-videoplayer/cordova-plugin-videoplayer.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-videoplayer"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-videoplayer/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-videoplayer"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-videoplayer/cordova-plugin-videoplayer.dev/url
+++ b/packages/cordova-plugin-videoplayer/cordova-plugin-videoplayer.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-videoplayer/archive/dev.tar.gz"
+checksum: "ed3309c5fe6f4d367ffa2dfd3b49567d"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-videoplayer using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-videoplayer
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-videoplayer
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-videoplayer/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
