### PR TITLE
cordova.dev - via opam-publish

### DIFF
--- a/packages/cordova/cordova.dev/descr
+++ b/packages/cordova/cordova.dev/descr
@@ -1,0 +1,1 @@
+Binding to the cordova object using gen_js_api.

--- a/packages/cordova/cordova.dev/opam
+++ b/packages/cordova/cordova.dev/opam
@@ -1,0 +1,12 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova"
+bug-reports: "https://github.com/dannywillems/ocaml-cordova/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova/cordova.dev/url
+++ b/packages/cordova/cordova.dev/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dannywillems/ocaml-cordova/archive/dev.tar.gz"
+checksum: "f6ea7c34d458880591b1bb3815cafdc5"


### PR DESCRIPTION
Binding to the cordova object using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova
- Source repo: https://github.com/dannywillems/ocaml-cordova
- Bug tracker: https://github.com/dannywillems/ocaml-cordova/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
