### PR TITLE
cordova-plugin-dialogs.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-dialogs/cordova-plugin-dialogs.dev/descr
+++ b/packages/cordova-plugin-dialogs/cordova-plugin-dialogs.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-dialogs using gen_js_api.

--- a/packages/cordova-plugin-dialogs/cordova-plugin-dialogs.dev/opam
+++ b/packages/cordova-plugin-dialogs/cordova-plugin-dialogs.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-dialogs"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-dialogs/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-dialogs"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-dialogs/cordova-plugin-dialogs.dev/url
+++ b/packages/cordova-plugin-dialogs/cordova-plugin-dialogs.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-dialogs/archive/dev.tar.gz"
+checksum: "ae61a01045d70fba9dab96798b99bca5"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-dialogs using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-dialogs
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-dialogs
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-dialogs/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
