### PR TITLE
cordova-plugin-datepicker.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-datepicker/cordova-plugin-datepicker.dev/descr
+++ b/packages/cordova-plugin-datepicker/cordova-plugin-datepicker.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-datepicker using gen_js_api.

--- a/packages/cordova-plugin-datepicker/cordova-plugin-datepicker.dev/opam
+++ b/packages/cordova-plugin-datepicker/cordova-plugin-datepicker.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-datepicker"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-datepicker/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-datepicker"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: ["gen_js_api" "ocaml-js-stdlib"]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-datepicker/cordova-plugin-datepicker.dev/url
+++ b/packages/cordova-plugin-datepicker/cordova-plugin-datepicker.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-datepicker/archive/dev.tar.gz"
+checksum: "1a01a228359b3211975e993630b3a2ed"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-datepicker using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-datepicker
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-datepicker
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-datepicker/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
