### PR TITLE
cordova-plugin-sim-card.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-sim-card/cordova-plugin-sim-card.dev/descr
+++ b/packages/cordova-plugin-sim-card/cordova-plugin-sim-card.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-sim using gen_js_api.

--- a/packages/cordova-plugin-sim-card/cordova-plugin-sim-card.dev/opam
+++ b/packages/cordova-plugin-sim-card/cordova-plugin-sim-card.dev/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-sim-card"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-sim-card/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-sim-card"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: ["gen_js_api" "cordova"]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-sim-card/cordova-plugin-sim-card.dev/url
+++ b/packages/cordova-plugin-sim-card/cordova-plugin-sim-card.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-sim-card/archive/dev.tar.gz"
+checksum: "3fb6ad2b9b02a3091d101ff00285ad37"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-sim using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-sim-card
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-sim-card
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-sim-card/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
