### PR TITLE
cordova-plugin-battery-status.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-battery-status/cordova-plugin-battery-status.dev/descr
+++ b/packages/cordova-plugin-battery-status/cordova-plugin-battery-status.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-battery-status using gen_js_api.

--- a/packages/cordova-plugin-battery-status/cordova-plugin-battery-status.dev/opam
+++ b/packages/cordova-plugin-battery-status/cordova-plugin-battery-status.dev/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-battery-status"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-battery-status/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-battery-status"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-battery-status/cordova-plugin-battery-status.dev/url
+++ b/packages/cordova-plugin-battery-status/cordova-plugin-battery-status.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-battery-status/archive/dev.tar.gz"
+checksum: "39d69f1569db4878c617b6aedd2fe7c3"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-battery-status using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-battery-status
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-battery-status
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-battery-status/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
