### PR TITLE
cordova-plugin-globalization.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-globalization/cordova-plugin-globalization.dev/descr
+++ b/packages/cordova-plugin-globalization/cordova-plugin-globalization.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-globalization using gen_js_api.

--- a/packages/cordova-plugin-globalization/cordova-plugin-globalization.dev/opam
+++ b/packages/cordova-plugin-globalization/cordova-plugin-globalization.dev/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-globalization"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-globalization/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-globalization"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: ["gen_js_api" "ocaml-js-stdlib"]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-globalization/cordova-plugin-globalization.dev/url
+++ b/packages/cordova-plugin-globalization/cordova-plugin-globalization.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-globalization/archive/dev.tar.gz"
+checksum: "cd4d4b91a0b1d7c2842b5ca898bf3dcf"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-globalization using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-globalization
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-globalization
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-globalization/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
