### PR TITLE
cordova-plugin-activityindicator.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-activityindicator/cordova-plugin-activityindicator.dev/descr
+++ b/packages/cordova-plugin-activityindicator/cordova-plugin-activityindicator.dev/descr
@@ -1,0 +1,1 @@
+Binding OCaml to cordova-plugin-activityindicator using gen_js_api

--- a/packages/cordova-plugin-activityindicator/cordova-plugin-activityindicator.dev/opam
+++ b/packages/cordova-plugin-activityindicator/cordova-plugin-activityindicator.dev/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-activityindicator"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-activityindicator/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-activityindicator"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-activityindicator/cordova-plugin-activityindicator.dev/url
+++ b/packages/cordova-plugin-activityindicator/cordova-plugin-activityindicator.dev/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-activityindicator/archive/dev.tar.gz"
+checksum: "1adab73c856a6a27cd110185486055b1"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-activityindicator using gen_js_api

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-activityindicator
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-activityindicator
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-activityindicator/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
