### PR TITLE
cordova-plugin-barcode-scanner.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-barcode-scanner/cordova-plugin-barcode-scanner.dev/descr
+++ b/packages/cordova-plugin-barcode-scanner/cordova-plugin-barcode-scanner.dev/descr
@@ -1,1 +1,1 @@
-Binding to the barcode scanner cordova plugin using gen_js_api
+Binding OCaml to cordova-plugin-barcode-scanner using gen_js_api

--- a/packages/cordova-plugin-barcode-scanner/cordova-plugin-barcode-scanner.dev/url
+++ b/packages/cordova-plugin-barcode-scanner/cordova-plugin-barcode-scanner.dev/url
@@ -1,3 +1,3 @@
 http:
-  "https://github.com/dannywillems/ocaml-cordova-plugin-barcodescanner/archive/dev.tar.gz"
-checksum: "bf8e4ed0b544a716b08afc784e45a4a1"
+  "https://github.com/dannywillems/ocaml-cordova-plugin-barcode-scanner/archive/dev.tar.gz"
+checksum: "177ac520d8b3320330e50621e72fbf78"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-barcode-scanner using gen_js_api

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-barcodescanner
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-barcodescanner
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-barcodescanner/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
