### PR TITLE
cordova-plugin-activity-indicator.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.dev/descr
+++ b/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.dev/descr
@@ -1,1 +1,1 @@
-Bindings OCaml to cordova plugin activity indicator using gen_js_api
+Binding OCaml to cordova-plugin-activity-indicator using gen_js_api

--- a/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.dev/opam
+++ b/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.dev/opam
@@ -2,12 +2,12 @@ opam-version: "1.2"
 maintainer: "Danny Willems <contact@danny-willems.be>"
 authors: "Danny Willems <contact@danny-willems.be>"
 homepage:
-  "https://github.com/dannywillems/ocaml-cordova-plugin-activityindicator"
+  "https://github.com/dannywillems/ocaml-cordova-plugin-activity-indicator"
 bug-reports:
-  "https://github.com/dannywillems/ocaml-cordova-plugin-activityindicator/issues"
+  "https://github.com/dannywillems/ocaml-cordova-plugin-activity-indicator/issues"
 license: "LGPL-3.0 with OCaml linking exception"
 dev-repo:
-  "https://github.com/dannywillems/ocaml-cordova-plugin-activityindicator"
+  "https://github.com/dannywillems/ocaml-cordova-plugin-activity-indicator"
 build: [make "build"]
 install: [make "install"]
 remove: [make "remove"]

--- a/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.dev/url
+++ b/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.dev/url
@@ -1,3 +1,3 @@
 http:
-  "https://github.com/dannywillems/ocaml-cordova-plugin-activityindicator/archive/dev.tar.gz"
-checksum: "2cc8ab02b859b66ef4585254e9f18595"
+  "https://github.com/dannywillems/ocaml-cordova-plugin-activity-indicator/archive/dev.tar.gz"
+checksum: "fc872751cbba0e76b4bce170add4970e"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-activity-indicator using gen_js_api

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-activity-indicator
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-activity-indicator
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-activity-indicator/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
