### PR TITLE
cordova-plugin-videoplayer.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-videoplayer/cordova-plugin-videoplayer.dev/descr
+++ b/packages/cordova-plugin-videoplayer/cordova-plugin-videoplayer.dev/descr
@@ -1,1 +1,1 @@
-Binding OCaml to cordova-plugin-videoplayer using gen_js_api.
+Binding OCaml to cordova-plugin-videoplayer using gen_js_api

--- a/packages/cordova-plugin-videoplayer/cordova-plugin-videoplayer.dev/url
+++ b/packages/cordova-plugin-videoplayer/cordova-plugin-videoplayer.dev/url
@@ -1,3 +1,3 @@
 http:
   "https://github.com/dannywillems/ocaml-cordova-plugin-videoplayer/archive/dev.tar.gz"
-checksum: "ed3309c5fe6f4d367ffa2dfd3b49567d"
+checksum: "3adb6ddc91b4c8f6168fd7a74a3bf8c1"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-videoplayer using gen_js_api

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-videoplayer
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-videoplayer
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-videoplayer/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.1
