### PR TITLE
cordova-plugin-activity-indicator.dev - via opam-publish

### DIFF
--- a/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.dev/descr
+++ b/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.dev/descr
@@ -1,1 +1,3 @@
 Binding OCaml to cordova-plugin-activity-indicator using gen_js_api
+
+Binding OCaml to cordova-plugin-activity-indicator using gen_js_api.

--- a/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.dev/url
+++ b/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.dev/url
@@ -1,3 +1,3 @@
 http:
-  "https://github.com/dannywillems/ocaml-cordova-plugin-activity-indicator/archive/dev.tar.gz"
-checksum: "fc872751cbba0e76b4bce170add4970e"
+  "https://github.com/dannywillems/ocaml-cordova-plugin-activity-indicator/archive/v1.0.tar.gz"
+checksum: "5a4187242a14092aa572d72a2569a2f2"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-activity-indicator using gen_js_api

Binding OCaml to cordova-plugin-activity-indicator using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-activity-indicator
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-activity-indicator
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-activity-indicator/issues

---

Pull-request generated by opam-publish v0.3.1
