### PR TITLE
cordova-plugin-activity-indicator.1.0 - via opam-publish

### DIFF
--- a/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.1.0/descr
+++ b/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.1.0/descr
@@ -1,0 +1,3 @@
+Binding OCaml to cordova-plugin-activity-indicator using gen_js_api.
+
+Binding OCaml to cordova-plugin-activity-indicator using gen_js_api.

--- a/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.1.0/opam
+++ b/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.1.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-activity-indicator"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-activity-indicator/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-activity-indicator"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.1.0/url
+++ b/packages/cordova-plugin-activity-indicator/cordova-plugin-activity-indicator.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-activity-indicator/archive/v1.0.tar.gz"
+checksum: "6559e42a3b423c34155bbc950c5f9b38"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-activity-indicator using gen_js_api.

Binding OCaml to cordova-plugin-activity-indicator using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-activity-indicator
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-activity-indicator
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-activity-indicator/issues

---

Pull-request generated by opam-publish v0.3.1
