### PR TITLE
cordova-plugin-battery-status.1.0 - via opam-publish

### DIFF
--- a/packages/cordova-plugin-battery-status/cordova-plugin-battery-status.1.0/descr
+++ b/packages/cordova-plugin-battery-status/cordova-plugin-battery-status.1.0/descr
@@ -1,0 +1,3 @@
+Binding OCaml to cordova-plugin-battery-status using gen_js_api.
+
+Binding OCaml to cordova-plugin-battery-status using gen_js_api.

--- a/packages/cordova-plugin-battery-status/cordova-plugin-battery-status.1.0/opam
+++ b/packages/cordova-plugin-battery-status/cordova-plugin-battery-status.1.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-battery-status"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-battery-status/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-battery-status"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-battery-status/cordova-plugin-battery-status.1.0/url
+++ b/packages/cordova-plugin-battery-status/cordova-plugin-battery-status.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-battery-status/archive/v1.0.tar.gz"
+checksum: "5d4c3cb434eaee3aca01e9c063264224"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-battery-status using gen_js_api.

Binding OCaml to cordova-plugin-battery-status using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-battery-status
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-battery-status
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-battery-status/issues

---

Pull-request generated by opam-publish v0.3.1
