### PR TITLE
cordova-plugin-camera.1.0 - via opam-publish

### DIFF
--- a/packages/cordova-plugin-camera/cordova-plugin-camera.1.0/descr
+++ b/packages/cordova-plugin-camera/cordova-plugin-camera.1.0/descr
@@ -1,0 +1,3 @@
+Binding OCaml to cordova-plugin-camera using gen_js_api.
+
+Binding OCaml to cordova-plugin-camera using gen_js_api.

--- a/packages/cordova-plugin-camera/cordova-plugin-camera.1.0/opam
+++ b/packages/cordova-plugin-camera/cordova-plugin-camera.1.0/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-camera"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-camera/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-camera"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-camera/cordova-plugin-camera.1.0/url
+++ b/packages/cordova-plugin-camera/cordova-plugin-camera.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-camera/archive/v1.0.tar.gz"
+checksum: "440e9e4a3126c654c1abc14bb9b646ac"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-camera using gen_js_api.

Binding OCaml to cordova-plugin-camera using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-camera
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-camera
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-camera/issues

---

Pull-request generated by opam-publish v0.3.1
