### PR TITLE
cordova-plugin-device-motion.1.0 - via opam-publish

### DIFF
--- a/packages/cordova-plugin-device-motion/cordova-plugin-device-motion.1.0/descr
+++ b/packages/cordova-plugin-device-motion/cordova-plugin-device-motion.1.0/descr
@@ -1,0 +1,3 @@
+Binding OCaml to cordova-plugin-device-motion using gen_js_api.
+
+Binding OCaml to cordova-plugin-device-motion using gen_js_api.

--- a/packages/cordova-plugin-device-motion/cordova-plugin-device-motion.1.0/opam
+++ b/packages/cordova-plugin-device-motion/cordova-plugin-device-motion.1.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-device-motion"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-device-motion/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-device-motion"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: ["gen_js_api" "ocaml-js-stdlib"]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-device-motion/cordova-plugin-device-motion.1.0/url
+++ b/packages/cordova-plugin-device-motion/cordova-plugin-device-motion.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-device-motion/archive/v1.0.tar.gz"
+checksum: "8c976b5e24d44aaaee220bb01989251c"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-device-motion using gen_js_api.

Binding OCaml to cordova-plugin-device-motion using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-device-motion
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-device-motion
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-device-motion/issues

---

Pull-request generated by opam-publish v0.3.1
