### PR TITLE
cordova-plugin-device-orientation.1.0 - via opam-publish

### DIFF
--- a/packages/cordova-plugin-device-orientation/cordova-plugin-device-orientation.1.0/descr
+++ b/packages/cordova-plugin-device-orientation/cordova-plugin-device-orientation.1.0/descr
@@ -1,0 +1,3 @@
+Binding OCaml to cordova-plugin-device-orientation using gen_js_api.
+
+Binding OCaml to cordova-plugin-device-orientation using gen_js_api.

--- a/packages/cordova-plugin-device-orientation/cordova-plugin-device-orientation.1.0/opam
+++ b/packages/cordova-plugin-device-orientation/cordova-plugin-device-orientation.1.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-device-orientation"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-device-orientation/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-device-orientation"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-device-orientation/cordova-plugin-device-orientation.1.0/url
+++ b/packages/cordova-plugin-device-orientation/cordova-plugin-device-orientation.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-device-orientation/archive/v1.0.tar.gz"
+checksum: "0502f619c8a28904247fd6274ec5205b"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-device-orientation using gen_js_api.

Binding OCaml to cordova-plugin-device-orientation using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-device-orientation
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-device-orientation
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-device-orientation/issues

---

Pull-request generated by opam-publish v0.3.1
