### PR TITLE
cordova-plugin-globalization.1.0 - via opam-publish

### DIFF
--- a/packages/cordova-plugin-globalization/cordova-plugin-globalization.1.0/descr
+++ b/packages/cordova-plugin-globalization/cordova-plugin-globalization.1.0/descr
@@ -1,0 +1,3 @@
+Binding OCaml to cordova-plugin-globalization using gen_js_api.
+
+Binding OCaml to cordova-plugin-globalization using gen_js_api.

--- a/packages/cordova-plugin-globalization/cordova-plugin-globalization.1.0/opam
+++ b/packages/cordova-plugin-globalization/cordova-plugin-globalization.1.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-globalization"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-globalization/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-globalization"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: ["gen_js_api" "ocaml-js-stdlib"]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-globalization/cordova-plugin-globalization.1.0/url
+++ b/packages/cordova-plugin-globalization/cordova-plugin-globalization.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-globalization/archive/v1.0.tar.gz"
+checksum: "ca0e9735354f39f0f650940b1ee1eabb"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-globalization using gen_js_api.

Binding OCaml to cordova-plugin-globalization using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-globalization
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-globalization
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-globalization/issues

---

Pull-request generated by opam-publish v0.3.1
