### PR TITLE
cordova-plugin-media.1.0 - via opam-publish

### DIFF
--- a/packages/cordova-plugin-media/cordova-plugin-media.1.0/descr
+++ b/packages/cordova-plugin-media/cordova-plugin-media.1.0/descr
@@ -1,0 +1,3 @@
+Binding OCaml to cordova-plugin-media using gen_js_api.
+
+Binding OCaml to cordova-plugin-media using gen_js_api.

--- a/packages/cordova-plugin-media/cordova-plugin-media.1.0/opam
+++ b/packages/cordova-plugin-media/cordova-plugin-media.1.0/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-media"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-media/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-media"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-media/cordova-plugin-media.1.0/url
+++ b/packages/cordova-plugin-media/cordova-plugin-media.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-media/archive/v1.0.tar.gz"
+checksum: "7a2d5ebe58b4e528424b6291495939e7"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-media using gen_js_api.

Binding OCaml to cordova-plugin-media using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-media
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-media
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-media/issues

---

Pull-request generated by opam-publish v0.3.1
