### PR TITLE
cordova-plugin-clipboard.1.0 - via opam-publish

### DIFF
--- a/packages/cordova-plugin-clipboard/cordova-plugin-clipboard.1.0/descr
+++ b/packages/cordova-plugin-clipboard/cordova-plugin-clipboard.1.0/descr
@@ -1,0 +1,3 @@
+Binding OCaml to cordova-plugin-clipboard using gen_js_api.
+
+Binding OCaml to cordova-plugin-clipboard using gen_js_api.

--- a/packages/cordova-plugin-clipboard/cordova-plugin-clipboard.1.0/opam
+++ b/packages/cordova-plugin-clipboard/cordova-plugin-clipboard.1.0/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova-plugin-clipboard"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-clipboard/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova-plugin-clipboard"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-clipboard/cordova-plugin-clipboard.1.0/url
+++ b/packages/cordova-plugin-clipboard/cordova-plugin-clipboard.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-clipboard/archive/v1.0.tar.gz"
+checksum: "3b2e370ada3292eebb2204391dce5814"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-clipboard using gen_js_api.

Binding OCaml to cordova-plugin-clipboard using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-clipboard
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-clipboard
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-clipboard/issues

---

Pull-request generated by opam-publish v0.3.1
