### PR TITLE
cordova.1.0 - via opam-publish

### DIFF
--- a/packages/cordova/cordova.1.0/descr
+++ b/packages/cordova/cordova.1.0/descr
@@ -1,0 +1,3 @@
+Binding OCaml to cordova Javascript object.
+
+Binding OCaml to cordova Javascript object.

--- a/packages/cordova/cordova.1.0/opam
+++ b/packages/cordova/cordova.1.0/opam
@@ -1,0 +1,12 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage: "https://github.com/dannywillems/ocaml-cordova"
+bug-reports: "https://github.com/dannywillems/ocaml-cordova/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo: "https://github.com/dannywillems/ocaml-cordova"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova/cordova.1.0/url
+++ b/packages/cordova/cordova.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/dannywillems/ocaml-cordova/archive/v1.0.tar.gz"
+checksum: "5c1a6939db179a8145ac49a036b3a64f"


### PR DESCRIPTION
Binding OCaml to cordova Javascript object.

Binding OCaml to cordova Javascript object.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova
- Source repo: https://github.com/dannywillems/ocaml-cordova
- Bug tracker: https://github.com/dannywillems/ocaml-cordova/issues

---

Pull-request generated by opam-publish v0.3.1
