### PR TITLE
cordova-plugin-email-composer.1.0 - via opam-publish

### DIFF
--- a/packages/cordova-plugin-email-composer/cordova-plugin-email-composer.1.0/descr
+++ b/packages/cordova-plugin-email-composer/cordova-plugin-email-composer.1.0/descr
@@ -1,0 +1,3 @@
+Binding OCaml to cordova-plugin-email-composer using gen_js_api.
+
+Binding OCaml to cordova-plugin-email-composer using gen_js_api.

--- a/packages/cordova-plugin-email-composer/cordova-plugin-email-composer.1.0/opam
+++ b/packages/cordova-plugin-email-composer/cordova-plugin-email-composer.1.0/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "Danny Willems <contact@danny-willems.be>"
+authors: "Danny Willems <contact@danny-willems.be>"
+homepage:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-email-composer"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-email-composer/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-email-composer"
+build: [make "build"]
+install: [make "install"]
+remove: [make "remove"]
+depends: "gen_js_api"
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-email-composer/cordova-plugin-email-composer.1.0/url
+++ b/packages/cordova-plugin-email-composer/cordova-plugin-email-composer.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-email-composer/archive/v1.0.tar.gz"
+checksum: "67b1e887916b54c56966d6f3eff47d2f"


### PR DESCRIPTION
Binding OCaml to cordova-plugin-email-composer using gen_js_api.

Binding OCaml to cordova-plugin-email-composer using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-email-composer
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-email-composer
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-email-composer/issues

---

Pull-request generated by opam-publish v0.3.1
