### PR TITLE
cordova-plugin-local-notifications.1.0 - via opam-publish

### DIFF
--- a/packages/cordova-plugin-local-notifications/cordova-plugin-local-notifications.1.0/descr
+++ b/packages/cordova-plugin-local-notifications/cordova-plugin-local-notifications.1.0/descr
@@ -1,0 +1,3 @@
+Binding to cordova-plugin-local-notifications using gen_js_api.
+
+Binding to cordova-plugin-local-notifications using gen_js_api.

--- a/packages/cordova-plugin-local-notifications/cordova-plugin-local-notifications.1.0/opam
+++ b/packages/cordova-plugin-local-notifications/cordova-plugin-local-notifications.1.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "Omar, Danny Willems (contact@danny-willems.be)"
+authors: "Omar"
+homepage: "https://github.com/o-marshmallow/ocaml-cordova-plugin-local-notifications"
+bug-reports:
+  "https://github.com/o-marshmallow/ocaml-cordova-plugin-local-notifications/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo:
+  "https://github.com/o-marshmallow/ocaml-cordova-plugin-local-notifications"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "cordova-plugin-local-notifications"]
+depends: [
+  "gen_js_api"
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-local-notifications/cordova-plugin-local-notifications.1.0/url
+++ b/packages/cordova-plugin-local-notifications/cordova-plugin-local-notifications.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-local-notifications/archive/v1.0.tar.gz"
+checksum: "bd701b0fe2f48e03565fa941e90199ec"


### PR DESCRIPTION
Binding to cordova-plugin-local-notifications using gen_js_api.

Binding to cordova-plugin-local-notifications using gen_js_api.

---
- Homepage: https://github.com/o-marshmallow/ocaml-cordova-plugin-local-notifications
- Source repo: https://github.com/o-marshmallow/ocaml-cordova-plugin-local-notifications
- Bug tracker: https://github.com/o-marshmallow/ocaml-cordova-plugin-local-notifications/issues

---

Pull-request generated by opam-publish v0.3.1
