### PR TITLE
cordova-plugin-background-mode.1.0 - via opam-publish

### DIFF
--- a/packages/cordova-plugin-background-mode/cordova-plugin-background-mode.1.0/descr
+++ b/packages/cordova-plugin-background-mode/cordova-plugin-background-mode.1.0/descr
@@ -1,0 +1,3 @@
+Binding to cordova-plugin-background-mode using gen_js_api.
+
+Binding to cordova-plugin-background-mode using gen_js_api.

--- a/packages/cordova-plugin-background-mode/cordova-plugin-background-mode.1.0/opam
+++ b/packages/cordova-plugin-background-mode/cordova-plugin-background-mode.1.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Omar, Danny Willems (contact@danny-willems.be)"
+authors: "Omar"
+homepage:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-background-mode"
+bug-reports:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-background-mode/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+dev-repo:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-background-mode"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "cordova-plugin-background-mode"]
+depends: [
+  "gen_js_api"
+  "ocamlfind" {build}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/cordova-plugin-background-mode/cordova-plugin-background-mode.1.0/url
+++ b/packages/cordova-plugin-background-mode/cordova-plugin-background-mode.1.0/url
@@ -1,0 +1,3 @@
+http:
+  "https://github.com/dannywillems/ocaml-cordova-plugin-background-mode/archive/v1.0.tar.gz"
+checksum: "8aded59720f0d3fdf3c6f7b5384acb9b"


### PR DESCRIPTION
Binding to cordova-plugin-background-mode using gen_js_api.

Binding to cordova-plugin-background-mode using gen_js_api.

---
- Homepage: https://github.com/dannywillems/ocaml-cordova-plugin-background-mode
- Source repo: https://github.com/dannywillems/ocaml-cordova-plugin-background-mode
- Bug tracker: https://github.com/dannywillems/ocaml-cordova-plugin-background-mode/issues

---

Pull-request generated by opam-publish v0.3.1
